### PR TITLE
fix: release rack version restrictions for published gem

### DIFF
--- a/lib/rack_reverse_proxy/version.rb
+++ b/lib/rack_reverse_proxy/version.rb
@@ -1,4 +1,4 @@
 #:nodoc:
 module RackReverseProxy
-  VERSION = "1.0.0".freeze
+  VERSION = "1.0.1".freeze
 end

--- a/rack-reverse-proxy.gemspec
+++ b/rack-reverse-proxy.gemspec
@@ -38,7 +38,7 @@ eos
   if ENV['RACK_VERSION'] == '2'
     spec.add_dependency 'rack', ">= 1.0.0", '< 3.0'
   else
-    spec.add_dependency 'rack', '>= 3.0', '< 4.0'
+    spec.add_dependency 'rack', ">= 1.0.0", '< 4.0'
     spec.add_dependency 'rackup', '~> 2.0'
   end
   spec.add_dependency "rack-proxy", "~> 0.6", ">= 0.6.1"


### PR DESCRIPTION
allows users to install with RACK_VERSION=2 without having to point to original repo